### PR TITLE
Fix tools logging

### DIFF
--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -644,5 +644,5 @@ async def execute_tool_server(
 
     except Exception as err:
         error = str(err)
-        log.exception("API Request Error:", error)
+        log.exception(f"API Request Error: {error}")
         return {"error": error}


### PR DESCRIPTION
## Summary
- fix exception logging in `utils/tools.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'test.util')*

------
https://chatgpt.com/codex/tasks/task_e_6845538c7a04832fa88ce5f1f60cb6f2